### PR TITLE
Added missing dependency for "unzip" (for linux)

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -36,7 +36,7 @@ To get all dependencies (except JDK) on Ubuntu execute the following commands in
 # ZDoom dependencies
 sudo apt-get install build-essential zlib1g-dev libsdl2-dev libjpeg-dev \
 nasm tar libbz2-dev libgtk2.0-dev cmake git libfluidsynth-dev libgme-dev \
-libopenal-dev timidity libwildmidi-dev
+libopenal-dev timidity libwildmidi-dev unzip
 
 # Boost libraries
 sudo apt-get install libboost-all-dev


### PR DESCRIPTION
List of dependencies was missing "unzip" which is not necessarily included in *nix installations. 