### PR TITLE
Update MacOS dependencies

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -74,7 +74,7 @@ To get dependencies install [homebrew](https://brew.sh/)
 
 ```sh
 # ZDoom dependencies and Boost libraries
-brew install cmake boost sdl2
+brew install cmake boost sdl2 wget
 
 # Python 2 dependencies
 brew install python


### PR DESCRIPTION
Because wget is not default command at MacOS [this script](https://github.com/mwydmuch/ViZDoom/blob/master/scripts/download_freedoom.sh#L16) can be failed.