### PR TITLE
add walls, floors/ceilings to label buffer

### DIFF
--- a/examples/python/labels.py
+++ b/examples/python/labels.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 
 from random import choice
 import vizdoom as vzd
+import numpy as np
 from argparse import ArgumentParser
 
 import cv2
@@ -76,6 +77,16 @@ if __name__ =="__main__":
             buffer[y + i, x, :] = color
             buffer[y + i, x + width, :] = color
 
+    def color_labels(labels):
+        """
+        Walls are blue, floor/ceiling are red (OpenCV uses BGR).
+        """
+        tmp = np.stack([labels] * 3, -1)
+        tmp[labels == 0] = [255, 0, 0]
+        tmp[labels == 1] = [0, 0, 255]
+
+        return tmp
+
 
     for i in range(episodes):
         print("Episode #" + str(i + 1))
@@ -93,7 +104,7 @@ if __name__ =="__main__":
             # Labels data are available in state.labels.
             labels = state.labels_buffer
             if labels is not None:
-                cv2.imshow('ViZDoom Labels Buffer', labels)
+                cv2.imshow('ViZDoom Labels Buffer', color_labels(labels))
 
             # Screen buffer, given in selected format. This buffer is always available.
             # Using information from state.labels draw bounding boxes.

--- a/src/vizdoom/src/r_draw.cpp
+++ b/src/vizdoom/src/r_draw.cpp
@@ -46,6 +46,7 @@
 
 //VIZDOOM_CODE
 #include "viz_depth.h"
+#include "viz_labels.h"
 
 #undef RANGECHECK
 
@@ -1123,6 +1124,11 @@ void R_DrawSpanP_C (void)
 			//  re-index using light/colormap.
 			*dest++ = colormap[source[spot]];
 			if(vizDepthMap!=NULL) vizDepthMap->setPoint(ds_x2-count+1,ds_y);
+            if(vizLabels!=NULL) {
+                vizLabels->setLabel(1);
+                vizLabels->setPoint(ds_x2-count+1,ds_y);
+                vizLabels->setLabel(0);
+            }
 			// Next step in u,v.
 			xfrac += xstep;
 			yfrac += ystep;

--- a/src/vizdoom/src/r_segs.cpp
+++ b/src/vizdoom/src/r_segs.cpp
@@ -53,6 +53,7 @@
 #include "v_palette.h"
 #include "r_data/colormaps.h"
 #include "viz_depth.h"
+#include "viz_labels.h"
 
 #define WALLYREPEAT 8
 
@@ -1312,6 +1313,14 @@ void wallscan (int x1, int x2, short *uwal, short *dwal, fixed_t *swal, fixed_t 
 					}*/
 				}
 			}
+            if(vizLabels!=NULL) {
+                vizLabels->setLabel(0);
+                for (unsigned int pcf = 0; pcf < 4; pcf++) {
+                    for (int c = 0; c <= dc_count; c++)
+                        vizLabels->setPoint(x + pcf, u4 + c);
+                }
+                vizLabels->setLabel(0);
+            }
 			dovline4();
 		}
 


### PR DESCRIPTION
This is a small modification I've added for a past project that uses semantic segmentation in ViZDoom.

We implemented full semantic segmentation,
where every pixel had a label such as pickup/enemy/other/walls/floor/ceiling,
and this was the only change to the C++ backend necessary.

This is definitely a hack at best,
but it worked well enough and wanted some advice on how to properly implement this.

![image](https://user-images.githubusercontent.com/7716849/54106899-d63c2f00-4394-11e9-915c-8a8295b97a23.png)