### PR TITLE
FIX: compile failed with new version of Julia and CxxWrap.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ vizdoom.egg-info/
 
 # MacOS
 .DS_Store
+.vscode/

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -186,7 +186,7 @@ To build Julia binding you first need to install CxxWrap package by running `jul
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Release \
 -DBUILD_JULIA=ON \
--DJlCxx_DIR=~/.julia/vX.X/CxxWrap/deps/usr/lib/cmake/JlCxx/
+-DJlCxx_DIR=~/.julia/packages/CxxWrap/<hash>/deps/usr/lib/cmake/JlCxx/
 ```
 
 

--- a/examples/julia/basic.jl
+++ b/examples/julia/basic.jl
@@ -1,20 +1,27 @@
-using CxxWrap
+module ViZDoom
+  using CxxWrap
+  @wrapmodule("../../bin/libvizdoomjl")
 
-wrap_modules("../../bin/libvizdoomjl")
+  function __init__()
+    @initcxx
+  end
+end
 
-const vz = ViZDoomWrapper
+const vz = ViZDoom
 
 game = vz.DoomGame()
 
+vz.load_config(game, "../../scenarios/basic.cfg")
 vz.set_doom_scenario_path(game, "../../scenarios/basic.wad")
 
 vz.set_doom_map(game, "map01")
 
+# config function need enums are not working.
 # Sets resolution. Default is 320X240
-vz.set_screen_resolution(game, vz.RES_640X480)
+#vz.set_screen_resolution(game, vz.RES_640X480)
 
 # Sets the screen buffer format. Not used here but now you can change it. Defalut is CRCGCB.
-vz.set_screen_format(game, vz.RGB24)
+#vz.set_screen_format(game, vz.RGB24)
 
 # Enables depth buffer.
 vz.set_depth_buffer_enabled(game, true)
@@ -40,12 +47,12 @@ vz.set_render_screen_flashes(game, true)  # Effect upon taking damage or picking
 
 
 # Adds buttons that will be allowed. 
-vz.add_available_button(game, vz.MOVE_LEFT)
-vz.add_available_button(game, vz.MOVE_RIGHT)
-vz.add_available_button(game, vz.ATTACK)
+#vz.add_available_button(game, vz.MOVE_LEFT)
+#vz.add_available_button(game, vz.MOVE_RIGHT)
+#vz.add_available_button(game, vz.ATTACK)
 
 # Adds vz variables that will be included in state.
-vz.add_available_game_variable(game, vz.AMMO2)
+#vz.add_available_game_variable(game, vz.AMMO2)
 
 # Causes episodes to finish after 200 tics (actions)
 vz.set_episode_timeout(game, 200)
@@ -63,7 +70,7 @@ vz.set_sound_enabled(game, true)
 vz.set_living_reward(game, -1)
 
 # Sets ViZDoom mode (PLAYER, ASYNC_PLAYER, SPECTATOR, ASYNC_SPECTATOR, PLAYER mode is default)
-vz.set_mode(game, vz.PLAYER)
+#vz.set_mode(game, vz.PLAYER)
 
 vz.init(game)
 

--- a/examples/julia/vizdoom
+++ b/examples/julia/vizdoom
@@ -1,0 +1,1 @@
+../../bin/vizdoom.app/Contents/MacOS/vizdoom

--- a/src/lib_julia/ViZDoomJuliaModule.cpp
+++ b/src/lib_julia/ViZDoomJuliaModule.cpp
@@ -31,8 +31,7 @@ struct IsBits<GameVariable> : std::true_type
 };
 } // namespace jlcxx
 
-JULIA_CPP_MODULE_BEGIN(registry)
-jlcxx::Module &mod = registry.create_module("ViZDoomWrapper");
+JLCXX_MODULE define_julia_module(jlcxx::Module& mod) {
 
 /* Consts */
 /*----------------------------------------------------------------------------------------------------------------*/
@@ -65,7 +64,7 @@ mod.set_const("BGRA32", BGRA32);
 mod.set_const("ABGR32", ABGR32);
 mod.set_const("GRAY8", GRAY8);
 mod.set_const("DOOM_256_COLORS8", DOOM_256_COLORS8);
-
+ 
 mod.add_bits<ScreenResolution>("ScreenResolution");
 mod.set_const("RES_160X120", RES_160X120);
 
@@ -458,4 +457,5 @@ mod.method("sec_to_doom_tics", secToDoomTics);
 mod.method("doom_fixed_to_double", [](double x) { return doomFixedToDouble(x); });
 mod.method("is_binary_button", isBinaryButton);
 mod.method("is_delta_button", isDeltaButton);
-JULIA_CPP_MODULE_END
+
+}


### PR DESCRIPTION
CxxWrap.jl have been upgraded, the previous version is not able to be compiled. I have fix the binding and example to match the new version. But one problem still not solved: all enums are not working, they are commented in example. I will try to fix it soon.