### PR TITLE
Vizdoom vizdoomcontroller sync fix

### DIFF
--- a/src/lib/ViZDoomController.cpp
+++ b/src/lib/ViZDoomController.cpp
@@ -444,6 +444,7 @@ namespace vizdoom {
             // Workaround for some problems
             this->sendCommand(std::string("map ") + this->map);
             this->MQDoom->send(MSG_CODE_TIC);
+            this->waitForDoomWork();
 
             this->sendCommand(std::string("playdemo ") + prepareLmpFilePath(demoPath));
 

--- a/src/lib/ViZDoomGame.cpp
+++ b/src/lib/ViZDoomGame.cpp
@@ -215,7 +215,8 @@ namespace vizdoom {
         this->summaryReward += reward;
         this->lastReward = reward;
 
-        this->lastMapTic = this->doomController->getMapTic();
+        if (this->doomController->isRunDoomAsync()) this->lastMapTic = this->doomController->getMapTic();
+        else this->lastMapTic = this->doomController->getMapLastTic();
 
         /* Update state */
         if (!this->isEpisodeFinished()) {


### PR DESCRIPTION
Two fixes:

- Add missing `DoomController::waitForDoomWork` after sending initial `MSG_CODE_TIC` when replaying LMP file. Else all subsequent TIC/UPDATE/TIC+UPDATES get ACK intended for prior request.
- When running synchronously get last tic from controller's record of last tic rather than shared memory. In the case where Doom runs ahead (e.g., `Mode.SPECTATOR`, non-async) this produces the expected living rewards. (Note: the fact that Doom is running ahead in this case may be undesired behavior and a bug given what `Mode.SPECTATOR` is intended to do).

See https://github.com/mwydmuch/ViZDoom/issues/412