### PR TITLE
Updated build & transitioning away from python2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ vizdoom.egg-info/
 # MacOS
 .DS_Store
 /build/
+/venv/
+/.eggs/

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ vizdoom.egg-info/
 
 # MacOS
 .DS_Store
+/build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
 dist: bionic
-group: deprecated-2017Q4
 language: cpp
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,12 @@ os:
 
 env:
   matrix:
-    - BINDING=anaconda2
+    # - BINDING=anaconda2
     - BINDING=anaconda3
     - BINDING=java
     #- BINDING=lua
     #- BINDING=torch
-    - BINDING=python2
+    #- BINDING=python2
     - BINDING=python3
 
 before_install:
@@ -49,7 +49,7 @@ before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ] && [ $BINDING == "java" ]; then sudo apt-get install -y default-jdk; fi
   #- if [ $TRAVIS_OS_NAME == "linux" ] && [ $BINDING == "lua" ]; then sudo apt-get install -y liblua5.1.0-dev; fi
   #- if [ $TRAVIS_OS_NAME == "linux" ] && [ $BINDING == "torch" ]; then ...; fi
-  - if [ $TRAVIS_OS_NAME == "linux" ] && [ $BINDING == "python2" ]; then sudo apt-get install -y python-dev python-numpy python-pip; fi
+  #- if [ $TRAVIS_OS_NAME == "linux" ] && [ $BINDING == "python2" ]; then sudo apt-get install -y python-dev python-numpy python-pip; fi
   - if [ $TRAVIS_OS_NAME == "linux" ] && [ $BINDING == "python3" ]; then sudo apt-get install -y python3-dev python3-numpy python3-pip; fi
 
   # OSX specific
@@ -57,7 +57,7 @@ before_install:
   #- if [ $TRAVIS_OS_NAME == "osx" ] && [ $BINDING == "java" ]; then ...; fi
   #- if [ $TRAVIS_OS_NAME == "osx" ] && [ $BINDING == "lua" ]; then ...; fi
   #- if [ $TRAVIS_OS_NAME == "osx" ] && [ $BINDING == "torch" ]; then ...; fi
-  - if [ $TRAVIS_OS_NAME == "osx" ] && [ $BINDING == "python2" ]; then brew install python; fi
+  # - if [ $TRAVIS_OS_NAME == "osx" ] && [ $BINDING == "python2" ]; then brew install python; fi
   - if [ $TRAVIS_OS_NAME == "osx" ] && [ $BINDING == "python3" ]; then brew install python3; fi
 
   # Anaconda/Miniconda
@@ -80,8 +80,8 @@ script:
   - if [ $BINDING == "torch" ]; then luarocks make; fi
 
   # Python install via pip
-  - if [ $BINDING == "anaconda2" ] || [ $BINDING == "anaconda3" ]; then python --version; python -m pip -v install .; fi
-  - if [ $BINDING == "python2" ]; then python --version; sudo pip -v install .; fi
+  # - if [ $BINDING == "anaconda2" ] || [ $BINDING == "anaconda3" ]; then python --version; python -m pip -v install .; fi
+  # - if [ $BINDING == "python2" ]; then python --version; sudo pip -v install .; fi
   - if [ $BINDING == "python3" ]; then python3 --version; sudo pip3 -v install .; fi
 
   # Python manual build

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ os:
 
 env:
   matrix:
-    - BINDING=anaconda3
     - BINDING=java
     #- BINDING=lua
     #- BINDING=torch
@@ -55,31 +54,8 @@ before_install:
   #- if [ $TRAVIS_OS_NAME == "osx" ] && [ $BINDING == "torch" ]; then ...; fi
   - if [ $TRAVIS_OS_NAME == "osx" ] && [ $BINDING == "python3" ]; then brew install python3; fi
 
-  # Anaconda/Miniconda
-  - if [ $BINDING == "anaconda2" ]; then
-    wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O anaconda.sh;
-    bash anaconda.sh -b -p $HOME/anaconda;
-    export PATH="$HOME/anaconda/bin:$PATH";
-    hash -r;
-    fi
-  - if [ $BINDING == "anaconda3" ]; then
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O anaconda.sh;
-    bash anaconda.sh -b -p $HOME/anaconda;
-    export PATH="$HOME/anaconda/bin:$PATH";
-    hash -r;
-    fi
-
 script:
   - if [ $BINDING == "java" ]; then cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA=ON; make; fi
   - if [ $BINDING == "lua" ]; then cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_LUA=ON; make; fi
   - if [ $BINDING == "torch" ]; then luarocks make; fi
-
-  # Python install via pip
   - if [ $BINDING == "python3" ]; then python3 --version; sudo pip3 -v install .; fi
-
-  # Python manual build
-  #- if [ $BINDING == "anaconda3" ]; then
-  #  cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_PYTHON3=ON -DPYTHON_INCLUDE_DIR=$HOME/anaconda/include/python3.6m -DPYTHON_LIBRARY=$HOME/anaconda/lib/libpython3.6m.so -DPYTHON_EXECUTABLE=$HOME/anaconda/bin/python3 -DNUMPY_INCLUDES=$HOME/anaconda/lib/python3.6/site-packages/numpy/core/include;
-  #  make;
-  #  fi
-  #- if [ $BINDING == "python3" ]; then cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_PYTHON3=ON; make; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: bionic
 group: deprecated-2017Q4
 language: cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,31 +33,26 @@ os:
 
 env:
   matrix:
-    # - BINDING=anaconda2
     - BINDING=anaconda3
     - BINDING=java
     #- BINDING=lua
     #- BINDING=torch
-    #- BINDING=python2
     - BINDING=python3
 
 before_install:
   - uname -a
 
   # Linux specific
-  #- if [ $TRAVIS_OS_NAME == "linux" ]; then sudo apt-get install -y cmake libboost-all-dev zlib1g-dev libsdl2-dev libjpeg-dev nasm tar libbz2-dev libgtk2.0-dev libfluidsynth-dev libgme-dev libopenal-dev timidity; fi
   - if [ $TRAVIS_OS_NAME == "linux" ] && [ $BINDING == "java" ]; then sudo apt-get install -y default-jdk; fi
   #- if [ $TRAVIS_OS_NAME == "linux" ] && [ $BINDING == "lua" ]; then sudo apt-get install -y liblua5.1.0-dev; fi
   #- if [ $TRAVIS_OS_NAME == "linux" ] && [ $BINDING == "torch" ]; then ...; fi
-  #- if [ $TRAVIS_OS_NAME == "linux" ] && [ $BINDING == "python2" ]; then sudo apt-get install -y python-dev python-numpy python-pip; fi
-  - if [ $TRAVIS_OS_NAME == "linux" ] && [ $BINDING == "python3" ]; then sudo apt-get install -y python3-dev python3-numpy python3-pip; fi
+  - if [ $TRAVIS_OS_NAME == "linux" ] && [ $BINDING == "python3" ]; then sudo apt-get install -y python3-dev python3-numpy python3-pip python3-setuptools; fi
 
   # OSX specific
   - if [ $TRAVIS_OS_NAME == "osx" ]; then brew reinstall wget cmake boost sdl2; fi
   #- if [ $TRAVIS_OS_NAME == "osx" ] && [ $BINDING == "java" ]; then ...; fi
   #- if [ $TRAVIS_OS_NAME == "osx" ] && [ $BINDING == "lua" ]; then ...; fi
   #- if [ $TRAVIS_OS_NAME == "osx" ] && [ $BINDING == "torch" ]; then ...; fi
-  # - if [ $TRAVIS_OS_NAME == "osx" ] && [ $BINDING == "python2" ]; then brew install python; fi
   - if [ $TRAVIS_OS_NAME == "osx" ] && [ $BINDING == "python3" ]; then brew install python3; fi
 
   # Anaconda/Miniconda
@@ -80,18 +75,11 @@ script:
   - if [ $BINDING == "torch" ]; then luarocks make; fi
 
   # Python install via pip
-  # - if [ $BINDING == "anaconda2" ] || [ $BINDING == "anaconda3" ]; then python --version; python -m pip -v install .; fi
-  # - if [ $BINDING == "python2" ]; then python --version; sudo pip -v install .; fi
   - if [ $BINDING == "python3" ]; then python3 --version; sudo pip3 -v install .; fi
 
   # Python manual build
-  #- if [ $BINDING == "anaconda2" ]; then
-  #  cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_PYTHON=ON -DPYTHON_INCLUDE_DIR=$HOME/anaconda/include/python2.7 -DPYTHON_LIBRARY=$HOME/anaconda/lib/libpython2.7.so -DPYTHON_EXECUTABLE=$HOME/anaconda/bin/python2.7 -DNUMPY_INCLUDES=$HOME/anaconda/lib/python2.7/site-packages/numpy/core/include;
-  #  make;
-  #  fi
   #- if [ $BINDING == "anaconda3" ]; then
   #  cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_PYTHON3=ON -DPYTHON_INCLUDE_DIR=$HOME/anaconda/include/python3.6m -DPYTHON_LIBRARY=$HOME/anaconda/lib/libpython3.6m.so -DPYTHON_EXECUTABLE=$HOME/anaconda/bin/python3 -DNUMPY_INCLUDES=$HOME/anaconda/lib/python3.6/site-packages/numpy/core/include;
   #  make;
   #  fi
-  #- if [ $BINDING == "python2" ]; then cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_PYTHON=ON; make; fi
   #- if [ $BINDING == "python3" ]; then cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_PYTHON3=ON; make; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,8 @@ endif ()
 find_package(Boost COMPONENTS filesystem thread system date_time chrono regex iostreams REQUIRED)
 find_package(Threads REQUIRED)
 
-set(VIZDOOM_OUTPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(VIZDOOM_OUTPUT_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 set(VIZDOOM_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(VIZDOOM_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(VIZDOOM_LIB_SRC_DIR ${VIZDOOM_SRC_DIR}/lib)
@@ -226,13 +227,13 @@ if (BUILD_PYTHON OR BUILD_PYTHON3)
 
     if (UNIX AND BUILD_ENGINE AND DOWNLOAD_FREEDOOM)
         add_custom_target(python_pip_package ALL
-                COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/assemble_pip_package.sh ${_PYTHON_VERSION}
+                COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/assemble_pip_package.sh ${_PYTHON_VERSION} ${VIZDOOM_OUTPUT_DIR} ${CMAKE_SOURCE_DIR}
                 COMMENT "Assembling pip package in ${VIZDOOM_PYTHON_OUTPUT_DIR}/pip_package")
     endif ()
     
     if (WIN32 AND DOWNLOAD_FREEDOOM)
         add_custom_target(python_pip_package ALL
-                COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/assemble_pip_package.bat ${_PYTHON_VERSION}
+                COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/assemble_pip_package.bat ${_PYTHON_VERSION} ${VIZDOOM_OUTPUT_DIR} ${CMAKE_SOURCE_DIR}
                 COMMENT "Assembling pip package in ${VIZDOOM_PYTHON_OUTPUT_DIR}/pip_package")
     endif ()
     
@@ -291,7 +292,7 @@ if (BUILD_LUA)
 
     if (UNIX AND BUILD_ENGINE AND DOWNLOAD_FREEDOOM)
         add_custom_target(luarocks_package ALL
-                COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/assemble_luarocks_package.sh
+                COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/assemble_luarocks_package.sh ${VIZDOOM_OUTPUT_DIR} ${CMAKE_SOURCE_DIR}
                 COMMENT "Assembling luarocks package in ${VIZDOOM_LUA_OUTPUT_DIR}/luarocks_package"
                 PROJECT_LABEL "Luarocks package")
 
@@ -403,12 +404,12 @@ endif ()
 
 if (UNIX AND DOWNLOAD_FREEDOOM)
     add_custom_target(freedoom2 ALL
-            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/download_freedoom.sh
+            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/download_freedoom.sh ${VIZDOOM_OUTPUT_DIR}
             COMMENT "Downloading freedoom2.wad")
 endif ()
 
 if (WIN32 AND DOWNLOAD_FREEDOOM)
     add_custom_target(freedoom2 ALL
-            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/download_freedoom.bat
+            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/download_freedoom.bat ${VIZDOOM_OUTPUT_DIR}
             COMMENT "Downloading freedoom2.wad")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,10 +133,10 @@ file(GLOB VIZDOOM_LIB_SOURCES
         ${VIZDOOM_LIB_SRC_DIR}/*.cpp)
 
 add_library(libvizdoom_static STATIC ${VIZDOOM_LIB_SOURCES})
-target_link_libraries(libvizdoom_static PRIVATE ${VIZDOOM_LIBS} gdtoa)
+target_link_libraries(libvizdoom_static PRIVATE ${VIZDOOM_LIBS})
 
 add_library(libvizdoom_shared SHARED ${VIZDOOM_LIB_SOURCES})
-target_link_libraries(libvizdoom_shared PRIVATE ${VIZDOOM_LIBS} gdtoa)
+target_link_libraries(libvizdoom_shared PRIVATE ${VIZDOOM_LIBS})
 
 set_target_properties(libvizdoom_static libvizdoom_shared
         PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,10 +133,10 @@ file(GLOB VIZDOOM_LIB_SOURCES
         ${VIZDOOM_LIB_SRC_DIR}/*.cpp)
 
 add_library(libvizdoom_static STATIC ${VIZDOOM_LIB_SOURCES})
-target_link_libraries(libvizdoom_static PRIVATE ${VIZDOOM_LIBS})
+target_link_libraries(libvizdoom_static PRIVATE ${VIZDOOM_LIBS} gdtoa)
 
 add_library(libvizdoom_shared SHARED ${VIZDOOM_LIB_SOURCES})
-target_link_libraries(libvizdoom_shared PRIVATE ${VIZDOOM_LIBS})
+target_link_libraries(libvizdoom_shared PRIVATE ${VIZDOOM_LIBS} gdtoa)
 
 set_target_properties(libvizdoom_static libvizdoom_shared
         PROPERTIES

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -175,7 +175,9 @@ Location of `site-packages` depends on Python distribution:
 
 In ViZDoom's root directory:
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_PYTHON=ON -DBUILD_JAVA=ON -DBUILD_LUA=ON -DBUILD_JULIA=ON
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_PYTHON=ON -DBUILD_JAVA=ON -DBUILD_LUA=ON -DBUILD_JULIA=ON
 make
 ```
 
@@ -184,7 +186,9 @@ where `-DBUILD_PYTHON=ON`, `-DBUILD_JAVA=ON`, `-DBUILD_LUA=ON` and `-DBUILD_JULI
 To build Julia binding you first need to install CxxWrap package by running `julia` and using `Pkg.add("CxxWrap")` command (see [Linux dependencies](#linux_deps)). Then you need to manually set `JlCxx_DIR` variable:
 
 ```sh
-cmake -DCMAKE_BUILD_TYPE=Release \
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release \
 -DBUILD_JULIA=ON \
 -DJlCxx_DIR=~/.julia/vX.X/CxxWrap/deps/usr/lib/cmake/JlCxx/
 ```
@@ -197,7 +201,9 @@ cmake -DCMAKE_BUILD_TYPE=Release \
 Run CMake and build generated Makefile.
 
 ```sh
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_PYTHON=ON -DBUILD_JAVA=ON -DBUILD_LUA=ON -DBUILD_JULIA=ON
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_PYTHON=ON -DBUILD_JAVA=ON -DBUILD_LUA=ON -DBUILD_JULIA=ON
 make
 ```
 
@@ -208,7 +214,9 @@ Users with brew-installed Python/Anaconda **may** need to manually set `PYTHON_E
 It should look like this for brew-installed Python (use `-DBUILD_PYTHON3=ON`, `include/pythonX.Xm` and `lib/libpythonX.Xm.dylib` for Python 3):
 
 ```sh
-cmake -DCMAKE_BUILD_TYPE=Release \
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release \
 -DBUILD_PYTHON=ON \
 -DPYTHON_EXECUTABLE=/usr/local/Cellar/python/X.X.X/Frameworks/Python.framework/Versions/X.X/bin/pythonX \
 -DPYTHON_INCLUDE_DIR=/usr/local/Cellar/python/X.X.X/Frameworks/Python.framework/Versions/X.X/include/pythonX.X \
@@ -219,7 +227,9 @@ cmake -DCMAKE_BUILD_TYPE=Release \
 Or for Anaconda (use `-DBUILD_PYTHON3=ON`, `include/pythonX.Xm` and `lib/libpythonX.Xm.dylib` for Python 3):
 
 ```sh
-cmake -DCMAKE_BUILD_TYPE=Release \
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release \
 -DBUILD_PYTHON=ON \
 -DPYTHON_EXECUTABLE=~/anacondaX/bin/pythonX \
 -DPYTHON_INCLUDE_DIR=~/anacondaX/include/pythonX.X \
@@ -230,7 +240,9 @@ cmake -DCMAKE_BUILD_TYPE=Release \
 To build Julia binding, you first need to install CxxWrap package by running `julia` and using `Pkg.add("CxxWrap")` command (see [MacOS dependencies](#macos_deps)). Then you need to manually set `JlCxx_DIR` variable:
 
 ```sh
-cmake -DCMAKE_BUILD_TYPE=Release \
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release \
 -DBUILD_JULIA=ON \
 -DJlCxx_DIR=~/.julia/vX.X/CxxWrap/deps/usr/lib/cmake/JlCxx/
 ```
@@ -260,7 +272,7 @@ Use generated Visual Studio solution to build all parts of ViZDoom environment.
 
 
 ### <a name="output"></a> Compilation output
-Compilation output will be placed in `vizdoom_root_dir/bin` and it should contain following files.
+Compilation output will be placed in `build/bin` and it should contain following files.
 
 * `bin/vizdoom / vizdoom.exe` - ViZDoom executable
 * `bin/vizdoom.pk3` - resources file used by ViZDoom (needed by ViZDoom executable)
@@ -277,6 +289,6 @@ Compilation output will be placed in `vizdoom_root_dir/bin` and it should contai
 
 ### <a name="manual-install"></a> Manual installation
 
-To manually install Python package copy `vizdoom_root_dir/bin/pythonX.X/pip_package` contents to `python_root_dir/lib/pythonX.X/site-packages/site-packages/vizdoom`.
+To manually install Python package copy `vizdoom_root_dir/build/bin/pythonX.X/pip_package` contents to `python_root_dir/lib/pythonX.X/site-packages/site-packages/vizdoom`.
 
-To manually install Torch package copy `vizdoom_root_dir/bin/lua/luarocks_package` contents to `torch_root_dir/install/lib/lua/5.1/vizdoom` and `vizdoom_root_dir/bin/lua/luarocks_shared_package` contents to `torch_root_dir/install/share/lua/5.1/vizdoom`.
+To manually install Torch package copy `vizdoom_root_dir/build/bin/lua/luarocks_package` contents to `torch_root_dir/install/lib/lua/5.1/vizdoom` and `vizdoom_root_dir/build/bin/lua/luarocks_shared_package` contents to `torch_root_dir/install/share/lua/5.1/vizdoom`.

--- a/doc/Quickstart.md
+++ b/doc/Quickstart.md
@@ -34,7 +34,9 @@ cd ViZDoom
 The library version numbers will change over time (e.g. `python3.6m`, `boost-python/1.64.0`) and may need to be updated. 
 
 ```sh
-cmake -DCMAKE_BUILD_TYPE=Release \
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release \
 -DBUILD_PYTHON3=ON \
 -DPYTHON_INCLUDE_DIR=$HOME/anaconda3/include/python3.6m \ 
 -DPYTHON_LIBRARY=$HOME/anaconda3/lib/libpython3.6m.dylib \
@@ -52,7 +54,7 @@ make
 5. Move the output to anaconda's `site-packages` directory, or your local virtual environments `site-packages` directory. 
 
 ```sh
-mv -r bin/python3/pip_package/ $HOME/anaconda3/lib/python3.6/site-packages/vizdoom
+mv -r build/bin/python3/pip_package/ $HOME/anaconda3/lib/python3.6/site-packages/vizdoom
 ```
 
 6. Test if it works.

--- a/scripts/assemble_luarocks_package.sh
+++ b/scripts/assemble_luarocks_package.sh
@@ -1,21 +1,22 @@
 #!/usr/bin/env bash
-
-PACKAGE_DEST_DIRECTORY="./bin/lua"
+BIN_PATH=$1
+SRC_PATH=$2
+PACKAGE_DEST_DIRECTORY="${BIN_PATH}/lua"
 PACKAGE_DEST_PATH="${PACKAGE_DEST_DIRECTORY}/luarocks_package"
 SHARED_PACKAGE_DEST_PATH="${PACKAGE_DEST_DIRECTORY}/luarocks_shared_package"
-PACKAGE_SOURCE="./src/lib_lua/src_lua"
+PACKAGE_SOURCE="${SRC_PATH}/src/lib_lua/src_lua"
 if [ "$(uname)" == "Darwin" ]; then
-    VIZDOOM_EXEC_PATH="./bin/vizdoom.app/Contents/MacOS/vizdoom"
+    VIZDOOM_EXEC_PATH="${BIN_PATH}/vizdoom.app/Contents/MacOS/vizdoom"
     LUA_BIN_PATH="${PACKAGE_DEST_DIRECTORY}/vizdoom.dylib"
 else
-    VIZDOOM_EXEC_PATH="./bin/vizdoom"
+    VIZDOOM_EXEC_PATH="${BIN_PATH}/vizdoom"
     LUA_BIN_PATH="${PACKAGE_DEST_DIRECTORY}/vizdoom.so"
 fi
 
-VIZDOOM_PK3_PATH="./bin/vizdoom.pk3"
-FREEDOOM_PATH="./bin/freedoom2.wad"
+VIZDOOM_PK3_PATH="${BIN_PATH}/vizdoom.pk3"
+FREEDOOM_PATH="${BIN_PATH}/freedoom2.wad"
 SCENARIOS_DEST_DIR="${PACKAGE_DEST_PATH}/scenarios"
-SCENARIOS_PATH="./scenarios"
+SCENARIOS_PATH="${SRC_PATH}/scenarios"
 
 if [ ! -e ${LUA_BIN_PATH} ]; then
     echo "Library for Lua does not exist. Aborting."

--- a/scripts/assemble_pip_package.bat
+++ b/scripts/assemble_pip_package.bat
@@ -2,24 +2,25 @@
 setlocal enabledelayedexpansion
 
 set PYTHON_VERSION=%1
+set BIN_PATH=%2
+set SRC_PATH=%3
 
-set BIN_PATH=.\bin
 set PACKAGE_DEST_DIRECTORY=%BIN_PATH%\python%PYTHON_VERSION%
 set PACKAGE_DEST_PATH=%PACKAGE_DEST_DIRECTORY%\pip_package
-set PACAKGE_INIT_FILE_SRC=.\src\lib_python\__init__.py
+set PACAKGE_INIT_FILE_SRC=%SRC_PATH%\src\lib_python\__init__.py
 
 set VIZDOOM_EXEC_PATH=%BIN_PATH%\vizdoom.exe
 set VIZDOOM_PK3_PATH=%BIN_PATH%\vizdoom.pk3
-dir dir .\bin\python%PYTHON_VERSION%\vizdoom*.pyd /b /s > %PACKAGE_DEST_DIRECTORY%\tmp.txt
+dir dir %BIN_PATH%\python%PYTHON_VERSION%\vizdoom*.pyd /b /s > %PACKAGE_DEST_DIRECTORY%\tmp.txt
 set /p PYTHON_BIN_PATH=<%PACKAGE_DEST_DIRECTORY%\tmp.txt
 del %PACKAGE_DEST_DIRECTORY%\tmp.txt
 set PYTHON_BIN_DEST_PATH=%PACKAGE_DEST_PATH%\vizdoom.pyd
 
 set FREEDOOM_PATH=%BIN_PATH%\freedoom2.wad
 set SCENARIOS_DEST_DIR=%PACKAGE_DEST_PATH%\scenarios
-set SCENARIOS_PATH=.\scenarios
+set SCENARIOS_PATH=%SRC_PATH%\scenarios
 set EXAMPLES_DEST_DIR=%PACKAGE_DEST_PATH%\examples
-set EXAMPLES_PATH=".\examples\python"
+set EXAMPLES_PATH=%SRC_PATH%\examples\python
 
 if not exist "%PYTHON_BIN_PATH%" (
     echo "Library for specified Python version does not exist. Aborting."

--- a/scripts/assemble_pip_package.sh
+++ b/scripts/assemble_pip_package.sh
@@ -1,30 +1,32 @@
 #!/usr/bin/env bash
 
 PYTHON_VERSION=$1
+BIN_PATH=$2
+SRC_PATH=$3
 
-if [ $# -ne 1 ];then
-    echo "Exactly one argument required. Aborting."
+if [ $# -ne 3 ];then
+    echo "Exactly three arguments required. Aborting."
     exit 1
 fi
 
-PACKAGE_DEST_DIRECTORY="./bin/python${PYTHON_VERSION}"
+PACKAGE_DEST_DIRECTORY="${BIN_PATH}/python${PYTHON_VERSION}"
 PACKAGE_DEST_PATH="${PACKAGE_DEST_DIRECTORY}/pip_package"
-PACKAGE_INIT_FILE_SRC="./src/lib_python/__init__.py"
+PACKAGE_INIT_FILE_SRC="${SRC_PATH}/src/lib_python/__init__.py"
 
 if [ "$(uname)" == "Darwin" ]; then
-    VIZDOOM_EXEC_PATH="./bin/vizdoom.app/Contents/MacOS/vizdoom"
+    VIZDOOM_EXEC_PATH="${BIN_PATH}/vizdoom.app/Contents/MacOS/vizdoom"
 else
-    VIZDOOM_EXEC_PATH="./bin/vizdoom"
+    VIZDOOM_EXEC_PATH="${BIN_PATH}/vizdoom"
 fi
 
-VIZDOOM_PK3_PATH="./bin/vizdoom.pk3"
+VIZDOOM_PK3_PATH="${BIN_PATH}/vizdoom.pk3"
 PYTHON_BIN_PATH="$(ls ${PACKAGE_DEST_DIRECTORY}/vizdoom*)"
 PYTHON_BIN_EXT="${PYTHON_BIN_PATH##*.}"
 PYTHON_BIN_DEST_PATH="${PACKAGE_DEST_PATH}/vizdoom.${PYTHON_BIN_EXT}"
 
-FREEDOOM_PATH="./bin/freedoom2.wad"
+FREEDOOM_PATH="${BIN_PATH}/freedoom2.wad"
 SCENARIOS_DEST_DIR="${PACKAGE_DEST_PATH}/scenarios"
-SCENARIOS_PATH="./scenarios"
+SCENARIOS_PATH="${SRC_PATH}/scenarios"
 
 if [ ! -e ${PYTHON_BIN_PATH} ]; then
     echo "Library for specified Python version does not exist. Aborting."

--- a/scripts/download_freedoom.bat
+++ b/scripts/download_freedoom.bat
@@ -1,6 +1,8 @@
 @echo off
 setlocal enabledelayedexpansion
 
+set FREEDOOM_DESTINATION_PATH=%1
+
 :: Checks if bin/freedoom2.wad is in place if not, the zip is downloaded (if not yet present) and freedoom2.wad is extracted to bin directory.
 
 :: Older version of freedoom
@@ -10,7 +12,6 @@ set FREEDOOM_ARCHIVE=%FREEDOOM_LINK:~0,-1%
 for %%F in (%FREEDOOM_LINK%) do set FREEDOOM_ARCHIVE=%%~nxF
 
 set FREEDOOM_OUTFILE=".\%FREEDOOM_ARCHIVE%"
-set FREEDOOM_DESTINATION_PATH=".\bin"
 set FREEDOOM_DESTINATION_FILE="%FREEDOOM_DESTINATION_PATH%\freedoom2.wad"
 
 if not exist "%FREEDOOM_DESTINATION_FILE%" (

--- a/scripts/download_freedoom.sh
+++ b/scripts/download_freedoom.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+FREEDOOM_DESTINATION_PATH=$1
+
 # Checks if bin/freedoom2.wad is in place if not, the zip is downloaded (if not yet present) and freedoom2.wad is extracted to bin directory.
 
 # Older version of freedoom
@@ -9,7 +11,6 @@ FREEDOOM_ARCHIVE=$(echo ${FREEDOOM_LINK} | cut -d '/' -f9)
 FREEDOOM_ARCHIVE_BASENAME=$(basename ${FREEDOOM_ARCHIVE} .zip)
 
 FREEDOOM_DOWNLOAD_PATH="."
-FREEDOOM_DESTINATION_PATH="./bin"
 
 if [ ! -e  "${FREEDOOM_DESTINATION_PATH}/freedoom2.wad" ]; then
 	if [ ! -e "${FREEDOOM_DOWNLOAD_PATH}/${FREEDOOM_ARCHIVE}" ]; then

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,6 @@ class CMakeBuild(build_ext):
                              "\nPlease check https://github.com/mwydmuch/ViZDoom/blob/master/doc/Building.md "
                              "for details\n\n\033[0m")
             raise
-        build_ext.run(self)
 
 
 setup(

--- a/src/vizdoom/CMakeLists.txt
+++ b/src/vizdoom/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CMAKE_CROSSCOMPILING)
 	include(${IMPORT_EXECUTABLES})
 endif(CMAKE_CROSSCOMPILING)
 
-set( ZDOOM_OUTPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../bin CACHE PATH "Directory where zdoom.pk3 and the executable will be created." )
+set( ZDOOM_OUTPUT_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 set( ZDOOM_EXE_NAME "vizdoom" CACHE FILEPATH "Name of the executable to create." )
 
 # Simplify pk3 building, add_pk3(filename srcdirectory)

--- a/src/vizdoom/gdtoa/CMakeLists.txt
+++ b/src/vizdoom/gdtoa/CMakeLists.txt
@@ -35,8 +35,6 @@ if( NOT MSVC AND NOT APPLE )
 	set( GEN_FP_DEPS ${CMAKE_CURRENT_BINARY_DIR}/arith.h ${CMAKE_CURRENT_BINARY_DIR}/gd_qnan.h )
 endif( NOT MSVC AND NOT APPLE )
 
-set( GEN_FP_DEPS ${CMAKE_CURRENT_BINARY_DIR}/arith.h ${CMAKE_CURRENT_BINARY_DIR}/gd_qnan.h )
-
 add_library( gdtoa
 	${GEN_FP_DEPS}
 	dmisc.c

--- a/src/vizdoom/gdtoa/CMakeLists.txt
+++ b/src/vizdoom/gdtoa/CMakeLists.txt
@@ -35,11 +35,14 @@ if( NOT MSVC AND NOT APPLE )
 	set( GEN_FP_DEPS ${CMAKE_CURRENT_BINARY_DIR}/arith.h ${CMAKE_CURRENT_BINARY_DIR}/gd_qnan.h )
 endif( NOT MSVC AND NOT APPLE )
 
+set( GEN_FP_DEPS ${CMAKE_CURRENT_BINARY_DIR}/arith.h ${CMAKE_CURRENT_BINARY_DIR}/gd_qnan.h )
+
 add_library( gdtoa
-	${GEN_FP_FILES}
+	${GEN_FP_DEPS}
 	dmisc.c
 	dtoa.c
 	misc.c
 	)
+target_include_directories(gdtoa PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries( gdtoa )
 


### PR DESCRIPTION
ViZDoom would not compile on a fresh installation of Ubuntu 16.04/18.04 due an error as in Issue #394 

This was because the gdtoa lib include files (that are autogenerated when the gdtoa library is built) are needed by the main ViZDoom source but not included in the main project. This is addressed by the changes in this pull request by modifiying [src/vizdoom/gdtoa/CMakeLists.txt](https://github.com/hadjilucasL/ViZDoom/blob/51a970299ed57d23896e7ce9699f946b401142aa/src/vizdoom/gdtoa/CMakeLists.txt#L44) to expose `arith.h`.

I have also added the configurations needed to move the `./bin` directory outside of its fixed location inside the source root. As is standard when compiling a project with CMake, the user creates a build directory and then generates and compiles the project in there, not within the source directory. The `bin` directory is now inside the CMake build dir. Have also updated the documentation where necessary.

I also started slowly transitioning things towards a python3 codebcase. I think this will simplify a lot of things and make it easier to maintain moving forward (but open to other suggestions).

Anaconda was also not really tested on Travis so also wondering if it will simplify things to keep the instructions just vanilla python3 virtualenv setup.

Resolves #394 