### PR TITLE
Change regex to work with GCC 10+ versions.

### DIFF
--- a/src/vizdoom/game-music-emu/CMakeLists.txt
+++ b/src/vizdoom/game-music-emu/CMakeLists.txt
@@ -84,7 +84,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
    if (__LIBGME_TEST_VISIBILITY)
       # get the gcc version
       exec_program(${CMAKE_CXX_COMPILER} ARGS --version OUTPUT_VARIABLE _gcc_version_info)
-      string (REGEX MATCH "[3-9]\\.[0-9]\\.[0-9]" _gcc_version "${_gcc_version_info}")
+      string (REGEX MATCH "[0-9]+\\.[0-9]\\.[0-9]" _gcc_version "${_gcc_version_info}")
 
       # gcc <4.1 had poor support for symbol visibility
       if ((${_gcc_version} VERSION_GREATER "4.1") OR (${_gcc_version} VERSION_EQUAL "4.1"))


### PR DESCRIPTION
Fixes build failing with GCC versions 10 and up.