### PR TITLE
Add info on conda install

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ pip install vizdoom
 ```
 We recommend using at least Ubuntu 18.04+ with Python 3.6+.
 
+### Conda
+To install ViZDoom on a conda environment (no system-wide installations required):
+```
+conda install -c conda-forge boost cmake gtk2 sdl2
+git clone https://github.com/mwydmuch/ViZDoom.git
+cd ViZDoom
+python setup.py build && python setup.py install
+```
+Note that `pip install vizdoom` won't work with conda install and you have to follow these steps.
+
 ### macOS 
 To install ViZDoom on macOS run (may take few minutes):
 ```

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -50,6 +50,18 @@ julia> using Pkg
 julia> Pkg.add("CxxWrap")
 ```
 
+If you do not have a root access, you can use a conda (e.g. [miniconda](https://docs.conda.io/en/latest/miniconda.html)) environment to install dependencies to your environment only:
+```
+conda install -c conda-forge boost cmake gtk2 sdl2
+```
+
+Note that to install ViZDoom in a conda environment you have to pull, build and install ViZDoom manually with
+```
+git clone https://github.com/mwydmuch/ViZDoom.git
+cd ViZDoom
+python setup.py build && python setup.py install
+```
+
 
 ### <a name="macos_deps"></a> MacOS
 * CMake 3.1+


### PR DESCRIPTION
Related comment: https://github.com/mwydmuch/ViZDoom/issues/495#issuecomment-1009438004

Tested to work on a Ubuntu 20.04 server machine where default vizdoom install fails (I do not have root access to install dependencies). 

Will request review explicitly once I have time to dig bit deeper into why `pip install vizdoom` fails in conda env.