### PR TITLE
Replace `CMAKE_SOURCE_DIR` with `PROJECT_SOURCE_DIR` when setting `CMAKE_MODULE_PATH`

### DIFF
--- a/src/vizdoom/CMakeLists.txt
+++ b/src/vizdoom/CMakeLists.txt
@@ -96,7 +96,7 @@ if( ZD_CMAKE_COMPILER_IS_GNUCXX_COMPATIBLE )
 	set( PROFILE 0 CACHE BOOL "Enable profiling with gprof for Debug and RelWithDebInfo build types." )
 endif( ZD_CMAKE_COMPILER_IS_GNUCXX_COMPATIBLE )
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}")
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}")
 
 option( NO_FMOD "Disable FMODEx sound support" OFF )
 option( NO_OPENAL "Disable OpenAL sound support" OFF )
@@ -121,7 +121,7 @@ if( MSVC )
 	# Function-level linking
 	# Disable run-time type information
 	set( ALL_C_FLAGS "/GF /Gy /GR-" )
-	
+
 	if( CMAKE_SIZEOF_VOID_P MATCHES "4")
 		# SSE2 option (mostly to switch it off in VC2012 and later where it's the default
 		option (ZDOOM_USE_SSE2	"Use SSE2 instruction set")
@@ -134,7 +134,7 @@ if( MSVC )
 			endif (MSVC_VERSION GREATER 1699)
 		endif (ZDOOM_USE_SSE2)
 	endif( CMAKE_SIZEOF_VOID_P MATCHES "4")
-	
+
 	# Avoid CRT DLL dependancies in release builds, optionally generate assembly output for checking crash locations.
 	option( ZDOOM_GENERATE_ASM "Generate assembly output." OFF )
 	if( ZDOOM_GENERATE_ASM )
@@ -143,7 +143,7 @@ if( MSVC )
 		set( REL_C_FLAGS "/MT /Oy /Oi" )
 	endif( ZDOOM_GENERATE_ASM )
 
-	
+
 	# Debug allocations in debug builds
 	set( DEB_C_FLAGS "/D _CRTDBG_MAP_ALLOC /MTd" )
 
@@ -151,7 +151,7 @@ if( MSVC )
 	if( MSVC_VERSION GREATER 1399 )
 		set( ALL_C_FLAGS "${ALL_C_FLAGS} /wd4996" )
 	endif( MSVC_VERSION GREATER 1399 )
-	
+
 	# The CMake configurations set /GR and /MD by default, which conflict with our settings.
 	string(REPLACE "/MD " " " CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE} )
 	string(REPLACE "/MD " " " CMAKE_CXX_FLAGS_MINSIZEREL ${CMAKE_CXX_FLAGS_MINSIZEREL} )

--- a/src/vizdoom/CMakeLists.txt
+++ b/src/vizdoom/CMakeLists.txt
@@ -96,8 +96,6 @@ if( ZD_CMAKE_COMPILER_IS_GNUCXX_COMPATIBLE )
 	set( PROFILE 0 CACHE BOOL "Enable profiling with gprof for Debug and RelWithDebInfo build types." )
 endif( ZD_CMAKE_COMPILER_IS_GNUCXX_COMPATIBLE )
 
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}")
-
 option( NO_FMOD "Disable FMODEx sound support" OFF )
 option( NO_OPENAL "Disable OpenAL sound support" OFF )
 

--- a/src/vizdoom/src/CMakeLists.txt
+++ b/src/vizdoom/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4)
 
-	set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}/cmake_modules")
+	set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/cmake_modules")
 
 if( COMMAND cmake_policy )
 	cmake_policy( SET CMP0003 NEW )
@@ -91,9 +91,9 @@ if( WIN32 )
 		set( WIN_TYPE Win32 )
 		set( XBITS x86 )
 	endif( X64 )
-	
+
 	add_definitions( -D_WIN32 )
-	
+
 	set( FMOD_SEARCH_PATHS
 		"C:/Program Files/FMOD SoundSystem/FMOD Programmers API ${WIN_TYPE}/api"
 		"C:/Program Files (x86)/FMOD SoundSystem/FMOD Programmers API ${WIN_TYPE}/api"
@@ -112,7 +112,7 @@ if( WIN32 )
 	else( NOT D3D_INCLUDE_DIR )
 		include_directories( ${D3D_INCLUDE_DIR} )
 	endif( NOT D3D_INCLUDE_DIR )
-	
+
 	find_path( XINPUT_INCLUDE_DIR xinput.h
 		PATHS ENV DXSDK_DIR
 		PATH_SUFFIXES Include )
@@ -154,7 +154,7 @@ if( WIN32 )
 		comdlg32
 		ws2_32
 		setupapi
-		oleaut32 
+		oleaut32
 		DelayImp )
 else( WIN32 )
 	if( APPLE )
@@ -190,11 +190,11 @@ else( WIN32 )
 		endif( NOT NO_GTK )
 	endif( APPLE )
 	set( NASM_NAMES nasm )
-	
+
 	if( NO_GTK )
 		add_definitions( -DNO_GTK=1 )
 	endif( NO_GTK )
-	
+
 	# Non-Windows version also needs SDL except native OS X backend
 	if( NOT WIN32 )
 		find_package( SDL2 REQUIRED )
@@ -303,7 +303,7 @@ find_package( FluidSynth )
 if( NOT NO_ASM )
 	if( UNIX AND X64 )
 		find_program( GAS_PATH as )
-		
+
 		if( GAS_PATH )
 			set( ASSEMBLER ${GAS_PATH} )
 		else( GAS_PATH )
@@ -334,7 +334,7 @@ if( NOT NO_ASM )
 	# I think the only reason there was a version requirement was because the
 	# executable name for Windows changed from 0.x to 2.0, right? This is
 	# how to do it in case I need to do something similar later.
-	
+
 	#	execute_process( COMMAND ${NASM_PATH} -v
 	#		OUTPUT_VARIABLE NASM_VER_STRING )
 	#	string( REGEX REPLACE ".*version ([0-9]+[.][0-9]+).*" "\\1" NASM_VER "${NASM_VER_STRING}" )
@@ -617,7 +617,7 @@ if( WIN32 )
 	set( SYSTEM_SOURCES_DIR win32 )
 	set( SYSTEM_SOURCES ${PLAT_WIN32_SOURCES} )
 	set( OTHER_SYSTEM_SOURCES ${PLAT_POSIX_SOURCES} ${PLAT_SDL_SOURCES} ${PLAT_OSX_SOURCES} ${PLAT_COCOA_SOURCES} )
-	
+
 	if( ZD_CMAKE_COMPILER_IS_GNUCXX_COMPATIBLE )
 		# CMake is not set up to compile and link rc files with GCC. :(
 		add_custom_command( OUTPUT zdoom-rc.o


### PR DESCRIPTION
Currently, usage of `${CMAKE_SOURCE_DIR}` during `${CMAKE_MODULE_PATH}` setup prevents ViZDoom as a subproject from correctly configuring.

This is because `${CMAKE_SOURCE_DIR}` in sub project will point to the top level CMakeLists.txt (aka parent project)'s directory:
```
set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}/cmake_modules")
```
will be substituted with
```
"${CMAKE_SOURCE_DIR};<parent project>;<parent project>/cmake_modules"
```

What's more, in `src/vizdoom/CMakeLists.txt`:
https://github.com/mwydmuch/ViZDoom/blob/ee8c6b10a09397981e38f1ba6c1bb9ef7eb204ab/src/vizdoom/CMakeLists.txt#L99

`CMAKE_MODULE_PATH` will be unconditionally set to `CMAKE_SOURCE_DIR`, thus preventing parent project from injecting correct module path at all. The final module path will therefore become
```
<parent project>;<parent project>;<parent project>/cmake_modules
```
#### Solution

Replacing `CMAKE_SOURCE_DIR` with `PROJECT_SOURCE_DIR` will fix the problem, since `PROJECT_SOURCE_DIR` will always points to project declaration located in ViZDoom's top level CMakeLists.txt.