### PR TITLE
Update gym version to  0.24

### DIFF
--- a/gym_wrapper/base_gym_env.py
+++ b/gym_wrapper/base_gym_env.py
@@ -143,6 +143,7 @@ class VizdoomEnv(gym.Env):
         return_info: bool = False,
         options: Optional[dict] = None,
     ):
+        super().reset(seed=seed)
         if seed is not None:
             self.game.set_seed(seed)
         self.game.new_episode()

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ setup(
     url='http://vizdoom.cs.put.edu.pl/',
     author='Marek Wydmuch, Michał Kempka, Wojciech Jaśkowski, Grzegorz Runc, Jakub Toczek',
     author_email='mwydmuch@cs.put.poznan.pl',
-    extras_require={"gym": ["gym==0.23.0", "pygame==2.1.0"]},
+    extras_require={"gym": ["gym==0.24.0", "pygame==2.1.0"]},
     install_requires=['numpy'],
     packages=['vizdoom'],
     package_dir={'vizdoom': package_path},

--- a/tests/test_gym_wrapper.py
+++ b/tests/test_gym_wrapper.py
@@ -27,7 +27,7 @@ def test_gym_wrapper():
             )
 
             # Test if env adheres to Gym API
-            check_env(env, warn=True, skip_render_check=True)
+            check_env(env, skip_render_check=True)
 
             ob_space = env.observation_space
             act_space = env.action_space


### PR DESCRIPTION
Per https://github.com/openai/gym/issues/2892#issuecomment-1155823477 the new gym env checker will enforce calling `super().reset(seed=seed)` in the reset function. 

Also `warn` option ignore/deprecated for check_env so removed that. 

`gym.env.registry.all()` on line 13 in `test_gym_wrapper.py` is deprecated in this version (now want `values()` instead) but just raises a warning so I left it there because using `value()` breaks gym version 0.23