### PR TITLE
Update gym version to 0.26

### DIFF
--- a/examples/python/gym_wrapper.py
+++ b/examples/python/gym_wrapper.py
@@ -15,5 +15,6 @@ if __name__  == '__main__':
         done = False
         obs = env.reset()
         while not done:
-            obs, rew, done, info = env.step(env.action_space.sample())
+            obs, rew, terminated, truncated, info = env.step(env.action_space.sample())
+            done = terminated or truncated
             env.render()

--- a/gym_wrapper/base_gym_env.py
+++ b/gym_wrapper/base_gym_env.py
@@ -220,7 +220,7 @@ class VizdoomEnv(gym.Env):
             image_list.append(automap_buffer)
 
         return np.concatenate(image_list, axis=1)
-    
+
     def render(self):
         render_image = self.__build_human_render_image()
         if self.render_mode == "rgb_array":

--- a/gym_wrapper/base_gym_env.py
+++ b/gym_wrapper/base_gym_env.py
@@ -20,6 +20,7 @@ class VizdoomEnv(gym.Env):
         level,
         frame_skip=1,
         max_buttons_pressed=1,
+        render_mode:Optional[str]=None,
     ):
         """
         Base class for Gym interface for ViZDoom. Thanks to https://github.com/shakenes/vizdoomgym
@@ -34,6 +35,7 @@ class VizdoomEnv(gym.Env):
                                        and [0, num_binary_buttons] number of binary buttons can be selected.
                                        If > 0, the binary action space becomes Discrete(n)
                                        and [0, max_buttons_pressed] number of binary buttons can be selected.
+            render_mode(Optional[str]): the render mode to use could be either 'human' or 'rgb_array'
 
         This environment forces window to be hidden. Use `render()` function to see the game.
 
@@ -54,6 +56,7 @@ class VizdoomEnv(gym.Env):
                           = Box(float32.min, float32.max, (num_delta_buttons,), float32).
         """
         self.frame_skip = frame_skip
+        self.render_mode  = render_mode
 
         # init game
         self.game = vzd.DoomGame()
@@ -217,12 +220,12 @@ class VizdoomEnv(gym.Env):
             image_list.append(automap_buffer)
 
         return np.concatenate(image_list, axis=1)
-
-    def render(self, mode="human"):
+    
+    def render(self):
         render_image = self.__build_human_render_image()
-        if mode == "rgb_array":
+        if self.render_mode == "rgb_array":
             return render_image
-        elif mode == "human":
+        elif self.render_mode == "human":
             # Transpose image (pygame wants (width, height, channels), we have (height, width, channels))
             render_image = render_image.transpose(1, 0, 2)
             if self.window_surface is None:

--- a/gym_wrapper/base_gym_env.py
+++ b/gym_wrapper/base_gym_env.py
@@ -16,6 +16,7 @@ LABEL_COLORS = np.random.default_rng(42).uniform(25, 256, size=(256, 3)).astype(
 
 class VizdoomEnv(gym.Env):
     metadata = {"render_modes": ["human","rgb_array"]}
+    
     def __init__(
         self,
         level,

--- a/gym_wrapper/base_gym_env.py
+++ b/gym_wrapper/base_gym_env.py
@@ -15,6 +15,7 @@ LABEL_COLORS = np.random.default_rng(42).uniform(25, 256, size=(256, 3)).astype(
 
 
 class VizdoomEnv(gym.Env):
+    metadata = {"render_modes": ["human","rgb_array"]}
     def __init__(
         self,
         level,

--- a/gym_wrapper/base_gym_env.py
+++ b/gym_wrapper/base_gym_env.py
@@ -106,9 +106,10 @@ class VizdoomEnv(gym.Env):
         env_action = self.__build_env_action(action)
         reward = self.game.make_action(env_action, self.frame_skip)
         self.state = self.game.get_state()
-        done = self.game.is_episode_finished()
+        terminated = self.game.is_episode_finished()
+        truncated = False # Trunctation to be handled by the TimeLimit wrapper
 
-        return self.__collect_observations(), reward, done, {}
+        return self.__collect_observations(), reward, terminated, truncated, {}
 
     def __parse_binary_buttons(self, env_action, agent_action):
         if self.num_binary_buttons != 0:
@@ -140,7 +141,6 @@ class VizdoomEnv(gym.Env):
         self,
         *,
         seed: Optional[int] = None,
-        return_info: bool = False,
         options: Optional[dict] = None,
     ):
         super().reset(seed=seed)
@@ -149,10 +149,7 @@ class VizdoomEnv(gym.Env):
         self.game.new_episode()
         self.state = self.game.get_state()
 
-        if not return_info:
-            return self.__collect_observations()
-        else:
-            return self.__collect_observations(), {}
+        return self.__collect_observations(), {}
 
     def __collect_observations(self):
         observation = {}

--- a/gym_wrapper/gym_env_defns.py
+++ b/gym_wrapper/gym_env_defns.py
@@ -6,8 +6,8 @@ from vizdoom import scenarios_path
 class VizdoomScenarioEnv(VizdoomEnv):
     """Basic ViZDoom environments which reside in the `scenarios` directory"""
     def __init__(
-        self, scenario_file, frame_skip=1, max_buttons_pressed=1
+        self, scenario_file, frame_skip=1, max_buttons_pressed=1, render_mode=None
     ):
         super(VizdoomScenarioEnv, self).__init__(
-           os.path.join(scenarios_path, scenario_file), frame_skip, max_buttons_pressed
+           os.path.join(scenarios_path, scenario_file), frame_skip, max_buttons_pressed, render_mode
         )

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ setup(
     url='http://vizdoom.cs.put.edu.pl/',
     author='Marek Wydmuch, Michał Kempka, Wojciech Jaśkowski, Grzegorz Runc, Jakub Toczek',
     author_email='mwydmuch@cs.put.poznan.pl',
-    extras_require={"gym": ["gym==0.24.0", "pygame==2.1.0"]},
+    extras_require={"gym": ["gym==0.26.0", "pygame==2.1.0"]},
     install_requires=['numpy'],
     packages=['vizdoom'],
     package_dir={'vizdoom': package_path},

--- a/tests/test_gym_wrapper.py
+++ b/tests/test_gym_wrapper.py
@@ -28,7 +28,7 @@ def test_gym_wrapper():
             )
 
             # Test if env adheres to Gym API
-            check_env(env, skip_render_check=True)
+            check_env(env.unwrapped, skip_render_check=True)
 
             ob_space = env.observation_space
             act_space = env.action_space

--- a/tests/test_gym_wrapper.py
+++ b/tests/test_gym_wrapper.py
@@ -4,13 +4,14 @@
 import os
 
 import gym
+from gym.spaces import Dict
 import numpy as np
 from gym.utils.env_checker import check_env
 from gym.spaces import Discrete, MultiDiscrete, Dict, Box
 from vizdoom.gym_wrapper.base_gym_env import VizdoomEnv
 from vizdoom import gym_wrapper
 
-vizdoom_envs = [env for env in [env_spec.id for env_spec in gym.envs.registry.all()] if "Vizdoom" in env]
+vizdoom_envs = [env for env in [env_spec.id for env_spec in gym.envs.registry.values()] if "Vizdoom" in env]
 test_env_configs = os.path.abspath("./env_configs")
 
 
@@ -31,7 +32,7 @@ def test_gym_wrapper():
 
             ob_space = env.observation_space
             act_space = env.action_space
-            ob = env.reset()
+            ob, _ = env.reset()
             assert ob_space.contains(ob), f"Reset observation: {ob!r} not in space"
 
             a = act_space.sample()
@@ -41,6 +42,7 @@ def test_gym_wrapper():
             ), f"Step observation: {observation!r} not in space"
             assert np.isscalar(reward), f"{reward} is not a scalar for {env}"
             assert isinstance(terminated, bool), f"Expected {terminated} to be a boolean"
+            assert isinstance(truncated, bool), f"Expected {truncated} to be a boolean"
 
             env.close()
 
@@ -85,15 +87,15 @@ def test_gym_wrapper_obs_space():
                    ]
     tri_channel_screen_obs_space = Box(0, 255, (240, 320, 3), dtype=np.uint8)
     single_channel_screen_obs_space = Box(0, 255, (240, 320, 1), dtype=np.uint8)
-    observation_spaces = [{"screen": tri_channel_screen_obs_space},
-                          {"screen": single_channel_screen_obs_space},
-                          {"screen": single_channel_screen_obs_space, "depth": single_channel_screen_obs_space,
-                           "labels": single_channel_screen_obs_space, "automap": single_channel_screen_obs_space},
-                          {"screen": single_channel_screen_obs_space, "depth": single_channel_screen_obs_space,
-                           "labels": single_channel_screen_obs_space},
-                          {"screen": tri_channel_screen_obs_space, "depth": single_channel_screen_obs_space},
-                          {"screen": tri_channel_screen_obs_space, "depth": single_channel_screen_obs_space,
-                           "labels": single_channel_screen_obs_space, "automap": tri_channel_screen_obs_space}
+    observation_spaces = [Dict({"screen": tri_channel_screen_obs_space}),
+                          Dict({"screen": single_channel_screen_obs_space}),
+                          Dict({"screen": single_channel_screen_obs_space, "depth": single_channel_screen_obs_space,
+                           "labels": single_channel_screen_obs_space, "automap": single_channel_screen_obs_space}),
+                          Dict({"screen": single_channel_screen_obs_space, "depth": single_channel_screen_obs_space,
+                           "labels": single_channel_screen_obs_space}),
+                          Dict({"screen": tri_channel_screen_obs_space, "depth": single_channel_screen_obs_space}),
+                          Dict({"screen": tri_channel_screen_obs_space, "depth": single_channel_screen_obs_space,
+                           "labels": single_channel_screen_obs_space, "automap": tri_channel_screen_obs_space})
                           ]
 
     for i in range(len(env_configs)):
@@ -104,7 +106,7 @@ def test_gym_wrapper_obs_space():
         )
         assert env.observation_space == observation_spaces[i], f"Incorrect observation space: {env.observation_space!r}, " \
                                                                f"should be: {observation_spaces[i]!r}"
-        obs = env.reset()
+        obs, _ = env.reset()
         assert env.observation_space.contains(obs), f"Step observation: {obs!r} not in space"
 
 

--- a/tests/test_gym_wrapper.py
+++ b/tests/test_gym_wrapper.py
@@ -6,7 +6,7 @@ import os
 import gym
 import numpy as np
 from gym.utils.env_checker import check_env
-from gym.spaces import Discrete, MultiDiscrete, Tuple, Dict, Box
+from gym.spaces import Discrete, MultiDiscrete, Dict, Box
 from vizdoom.gym_wrapper.base_gym_env import VizdoomEnv
 from vizdoom import gym_wrapper
 
@@ -35,12 +35,12 @@ def test_gym_wrapper():
             assert ob_space.contains(ob), f"Reset observation: {ob!r} not in space"
 
             a = act_space.sample()
-            observation, reward, done, _info = env.step(a)
+            observation, reward, terminated, truncated, _info = env.step(a)
             assert ob_space.contains(
                 observation
             ), f"Step observation: {observation!r} not in space"
             assert np.isscalar(reward), f"{reward} is not a scalar for {env}"
-            assert isinstance(done, bool), f"Expected {done} to be a boolean"
+            assert isinstance(terminated, bool), f"Expected {terminated} to be a boolean"
 
             env.close()
 
@@ -59,10 +59,13 @@ def test_gym_wrapper_terminal_state():
 
             agent = lambda ob: env.action_space.sample()
             ob = env.reset()
-            done = False
+            terminated = False
+            truncated = False
+            done = terminated or truncated
             while not done:
                 a = agent(ob)
-                (ob, _reward, done, _info) = env.step(a)
+                (ob, _reward, terminated, truncated, _info) = env.step(a)
+                done = terminated or truncated
                 if done:
                     break
                 env.close()


### PR DESCRIPTION
Update `gym_wrapper`  to be compatible with the newly released version 0.26. 
Release note - https://github.com/openai/gym/pull/3056

Changes made here include;
1. Use of the new step API
2. Update the render; setting the render_mode on instantiation
3. Always return `info` on reset
4. Update the tests to conform to the new API

@pseudo-rnd-thoughts